### PR TITLE
Fix content-node setup instructions

### DIFF
--- a/content-node/ubuntu-vm/README.md
+++ b/content-node/ubuntu-vm/README.md
@@ -1,5 +1,5 @@
 ### Content Node on Ubuntu VM
 
 1. Rename `values.env.example` to `values.env`
-2. Run the script with `sudo sh content-node-setup.sh <absolute-path-to-env-file>`
+2. Run the script with `sudo bash content-node-setup.sh <absolute-path-to-env-file>`
 3. Curl `localhost:30080/statusz` to make sure the server is up and returning a response


### PR DESCRIPTION
Doesn't work with `sh` due to brackets.